### PR TITLE
Properly name commonjs output file

### DIFF
--- a/build.cjs
+++ b/build.cjs
@@ -9,7 +9,7 @@ const shared = {
 
 build({
     ...shared,
-    outfile: "dist/cjs/index.js",
+    outfile: "dist/cjs/index.cjs",
     format: "cjs",
 });
 

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
         "dist"
     ],
     "browser": "dist/js/index.js",
-    "main": "dist/cjs/index.js",
-    "module": "dist/js/index.js",
+    "main": "dist/cjs/index.cjs",
+    "module": "dist/js/index.cjs",
     "types": "dist/ts/index.d.ts",
     "exports": {
-        "import": "./dist/js/index.js",
+        "import": "./dist/js/index.cjs",
         "require": "./dist/cjs/index.js"
     },
     "scripts": {


### PR DESCRIPTION
Hello, I just discovered your library. It's really great, I just have one issue with it. When trying to use it in a node environement, node doesn't seem to be happy with it. It gave me this error:
```
$ ts-node index.ts
[...]/node_modules/ts-node/dist/index.js:842
            return old(m, filename);
                   ^
Error [ERR_REQUIRE_ESM]: require() of ES Module [...]/node_modules/canvas-hypertxt/dist/cjs/index.js from [...]/src/utils/Agenda.ts not supported.
index.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename index.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in [...]/node_modules/canvas-hypertxt/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
```

This is caused by the fact that you defined `type: module` in your package.json. This isn't a problem in itself, but it becomes a problem when using it as a commonjs module.

This PR aims to fix that issue by naming the commonjs output properly, as node asks.