### PR TITLE
Fix typings not found error

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "browser": "dist/js/index.js",
     "main": "dist/cjs/index.cjs",
     "module": "dist/js/index.js",
-    "types": "dist/ts/index.d.ts",
+    "types": "dist/ts/src/index.d.ts",
     "exports": {
         "import": "./dist/js/index.js",
         "require": "./dist/cjs/index.cjs"


### PR DESCRIPTION
The package.json `typings` parameter is pointing to a non-existing `index.d.ts`. This PR updates the path to `dist/ts/src/index.d.ts` and fixes TypeScript errors in my project.