### PR TITLE
Fix types location

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import { split } from "canvas-hypertxt";
 function renderWrappedText(ctx: CanvasRenderingContext2D, value: string, width: number, x: number, y: number) {
     ctx.font = "12px sans-serif"; // ideally don't do this every time, it is really slow.
     ctx.textBaseline = "top"; // just makes positioning easier to predict, not essential
-    const lines = split(ctx, value, "12px sans-serif", width);
+    const lines = split(ctx, value, "12px sans-serif", width, true);
     for (const line of lines) {
         ctx.fillText(line, x, y);
         y += 15;
@@ -28,7 +28,7 @@ function renderWrappedTextCentered(ctx: CanvasRenderingContext2D, value: string,
     ctx.font = "12px sans-serif";
     ctx.textAlign = "center";
     ctx.textBaseline = "top";
-    const lines = split(ctx, value, "12px sans-serif", width);
+    const lines = split(ctx, value, "12px sans-serif", width, true);
     for (const line of lines) {
         ctx.fillText(line, x + width / 2, y);
         y += 15;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "browser": "dist/js/index.js",
     "main": "dist/cjs/index.cjs",
     "module": "dist/js/index.js",
-    "types": "dist/ts/index.d.ts",
+    "types": "dist/ts/src/index.d.ts",
     "exports": {
         "import": "./dist/js/index.js",
         "require": "./dist/cjs/index.cjs"


### PR DESCRIPTION
The types were not being found correctly, they are in a `/src/` sub-directory.

I also added the hyper wrapping boolean as the types have it as required.